### PR TITLE
Remove Version Numbers from Install Folder and File Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@
 実際の実行例
 
 ```
-./app.rb ~/Workspaces/github/kogaki/toonz/opentoonz/toonz/build/toonz/OpenToonz_1.2.app ~/Workspaces/github/kogaki/toonz/opentoonz/stuff 0.0.1 ~/Qt5.9.2/5.9.2/clang_64/bin/macdeployqt ~/Qt5.9.2/5.9.2/clang_64/lib
+./app.rb ~/Workspaces/github/kogaki/toonz/opentoonz/toonz/build/toonz/OpenToonz.app ~/Workspaces/github/kogaki/toonz/opentoonz/stuff 0.0.1 ~/Qt5.9.2/5.9.2/clang_64/bin/macdeployqt ~/Qt5.9.2/5.9.2/clang_64/lib
 ```
 
 ### rpath の確認
 
 ```
-otool -l ~/Workspaces/github/kogaki/toonz/opentoonz/toonz/build/toonz/OpenToonz_1.2.app/Contents/MacOS/OpenToonz_1.2
+otool -l ~/Workspaces/github/kogaki/toonz/opentoonz/toonz/build/toonz/OpenToonz.app/Contents/MacOS/OpenToonz
 ```
 
 すると、

--- a/app.rb
+++ b/app.rb
@@ -21,7 +21,7 @@ VERSION = ARGV[2]
 MACDEPLOYQT_PATH = ARGV[3]
 DELETE_RPATH = ARGV[4]
 VIRTUAL_ROOT = "VirtualRoot"
-INSTALL_BUNDLE = "OpenToonz_1.2.app"
+INSTALL_BUNDLE = "OpenToonz.app"
 APP = "Applications"
 THIS_DIRECTORY = File.dirname(__FILE__)
 
@@ -44,7 +44,7 @@ exec_with_assert "mv #{INSTALL_BUNDLE} #{VIRTUAL_ROOT}/#{APP}"
 
 # LC_RPATH から自分の名前を削除
 # 削除する RPATH を指定
-DELETE_RPATH_TARGET = "#{VIRTUAL_ROOT}/#{APP}/#{INSTALL_BUNDLE}/Contents/MacOS/OpenToonz_1.2"
+DELETE_RPATH_TARGET = "#{VIRTUAL_ROOT}/#{APP}/#{INSTALL_BUNDLE}/Contents/MacOS/OpenToonz"
 exec_with_assert "install_name_tool -delete_rpath #{DELETE_RPATH} #{DELETE_RPATH_TARGET}"
 
 # plist が存在しない場合は生成し、必要な変更を適用

--- a/scripts/pkg-script.sh
+++ b/scripts/pkg-script.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-STUFF_DIR="OpenToonz_1.2_stuff"
+STUFF_DIR="OpenToonz_stuff"
 tar xzvf stuff.tar.bz2
 mv stuff $STUFF_DIR
 mkdir /Applications/OpenToonz


### PR DESCRIPTION
This PR will remove version numbers from install folder and file name.
The default destination of the stuff folder will become `/Applications/OpenToonz/OpenToonz_stuff` .
Also note that Jenkins settings must be updated just before merging this.